### PR TITLE
Add length warning message and stop empty passwords

### DIFF
--- a/src/components/Input.js
+++ b/src/components/Input.js
@@ -114,7 +114,9 @@ export default function Input() {
             }}
           />
         </Row>
-        {passwordError && <ErrorMessage>Password Not Long Enough</ErrorMessage>}
+        {passwordError && (
+          <ErrorMessage>Minimum Length 4 Characters</ErrorMessage>
+        )}
       </form>
     </Container>
   )

--- a/src/components/Input.js
+++ b/src/components/Input.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 import styled from 'styled-components'
 
 import { Container, Row } from './Common'
@@ -38,8 +38,32 @@ const Button = styled.button({
   cursor: 'pointer',
 })
 
+const ErrorMessage = styled.p({
+  color: '#ff7272',
+  fontFamily: 'Monaco',
+  fontStyle: 'normal',
+  fontWeight: '400',
+  fontSize: '24px',
+  lineHeight: '32px',
+})
+
 export default function Input() {
   const { update, demo1 } = React.useContext(Context)
+  const [passwordError, SetPasswordError] = useState(false)
+  const passwordLowerBound = 1
+  const passwordUpperBound = 4
+
+  useEffect(() => {
+    if (
+      demo1.password.length === passwordLowerBound ||
+      (demo1.password.length < passwordUpperBound &&
+        demo1.password.length >= passwordLowerBound)
+    ) {
+      SetPasswordError(true)
+    } else {
+      SetPasswordError(false)
+    }
+  }, [demo1.password])
 
   const passwordChange = (e) => {
     e.preventDefault()
@@ -53,12 +77,14 @@ export default function Input() {
 
   const enterPassword = (e) => {
     e.preventDefault()
-    update({
-      demo1: {
-        ...demo1,
-        isPasswordSet: true,
-      },
-    })
+    if (demo1.password.length >= passwordUpperBound) {
+      update({
+        demo1: {
+          ...demo1,
+          isPasswordSet: true,
+        },
+      })
+    }
   }
 
   return (
@@ -88,6 +114,7 @@ export default function Input() {
             }}
           />
         </Row>
+        {passwordError && <ErrorMessage>Password Not Long Enough</ErrorMessage>}
       </form>
     </Container>
   )

--- a/src/components/Input.js
+++ b/src/components/Input.js
@@ -49,9 +49,11 @@ const ErrorMessage = styled.p({
 
 export default function Input() {
   const { update, demo1 } = React.useContext(Context)
-  const [passwordError, SetPasswordError] = useState(false)
+  const [passwordMinError, SetPasswordMinError] = useState(false)
+  const [passwordMaxError, SetPasswordMaxError] = useState(false)
   const passwordLowerBound = 1
   const passwordUpperBound = 4
+  const passwordMaxBound = 16
 
   useEffect(() => {
     if (
@@ -59,9 +61,12 @@ export default function Input() {
       (demo1.password.length < passwordUpperBound &&
         demo1.password.length >= passwordLowerBound)
     ) {
-      SetPasswordError(true)
+      SetPasswordMinError(true)
+    } else if (demo1.password.length === passwordMaxBound) {
+      SetPasswordMaxError(true)
     } else {
-      SetPasswordError(false)
+      SetPasswordMinError(false)
+      SetPasswordMaxError(false)
     }
   }, [demo1.password])
 
@@ -114,10 +119,13 @@ export default function Input() {
             }}
           />
         </Row>
-        {passwordError && (
+        {passwordMinError && (
           <ErrorMessage>
             Minimum Password Length: <br /> {passwordUpperBound} Characters
           </ErrorMessage>
+        )}
+        {passwordMaxError && (
+          <ErrorMessage>Maximum Password Reached</ErrorMessage>
         )}
       </form>
     </Container>

--- a/src/components/Input.js
+++ b/src/components/Input.js
@@ -43,7 +43,7 @@ const ErrorMessage = styled.p({
   fontFamily: 'Monaco',
   fontStyle: 'normal',
   fontWeight: '400',
-  fontSize: '24px',
+  fontSize: '20px',
   lineHeight: '32px',
 })
 

--- a/src/components/Input.js
+++ b/src/components/Input.js
@@ -115,7 +115,9 @@ export default function Input() {
           />
         </Row>
         {passwordError && (
-          <ErrorMessage>Minimum Length 4 Characters</ErrorMessage>
+          <ErrorMessage>
+            Minimum Password Length: <br /> 4 Characters
+          </ErrorMessage>
         )}
       </form>
     </Container>

--- a/src/components/Input.js
+++ b/src/components/Input.js
@@ -116,7 +116,7 @@ export default function Input() {
         </Row>
         {passwordError && (
           <ErrorMessage>
-            Minimum Password Length: <br /> 4 Characters
+            Minimum Password Length: <br /> {passwordUpperBound} Characters
           </ErrorMessage>
         )}
       </form>


### PR DESCRIPTION
If the the secret is below 4 characters a warning is displayed below. There are also checks to stop empty or small passwords (4 characters) being submitted.

<img width="1013" alt="Screenshot 2022-08-31 at 13 35 08" src="https://user-images.githubusercontent.com/35331926/187680923-4e8f40ad-3131-4619-bdbd-0759e778c7d3.png">

<img width="1013" alt="Screenshot 2022-08-31 at 14 32 44" src="https://user-images.githubusercontent.com/35331926/187690918-d5552b22-b237-4732-a331-207b2d783553.png">

<img width="1013" alt="Screenshot 2022-08-31 at 14 32 50" src="https://user-images.githubusercontent.com/35331926/187690951-7ee8d81d-cbf9-48e5-a476-e80035278449.png">

<img width="1013" alt="Screenshot 2022-08-31 at 14 32 55" src="https://user-images.githubusercontent.com/35331926/187690969-1ef9e40a-3429-45f4-88f7-3dc6a04a4735.png">


<img width="1013" alt="Screenshot 2022-08-31 at 13 35 38" src="https://user-images.githubusercontent.com/35331926/187680976-d6db45e1-3d37-4248-8c27-c3cdc53f676b.png">
