### PR TITLE
Add length warning message and stop empty passwords

### DIFF
--- a/src/components/shared/Input.js
+++ b/src/components/shared/Input.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState, useEffect } from 'react'
 import styled from 'styled-components'
 
 import { Container, Row } from './Common'
@@ -7,10 +7,31 @@ import { Context } from '../../utils/context'
 const PasswordInput = styled.input((props) => props)
 const Label = styled.label((props) => props)
 const Button = styled.button((props) => props)
+const Warning = styled.p((props) => props)
 
 export default function Input(demo1) {
   const { update } = React.useContext(Context)
   const { password } = demo1.theme
+  const [passwordMinError, SetPasswordMinError] = useState(false)
+  const [passwordMaxError, SetPasswordMaxError] = useState(false)
+  const passwordLowerBound = 1
+  const passwordUpperBound = 4
+  const passwordMaxBound = 16
+
+  useEffect(() => {
+    if (
+      demo1.password.length === passwordLowerBound ||
+      (demo1.password.length < passwordUpperBound &&
+        demo1.password.length >= passwordLowerBound)
+    ) {
+      SetPasswordMinError(true)
+    } else if (demo1.password.length === passwordMaxBound) {
+      SetPasswordMaxError(true)
+    } else {
+      SetPasswordMinError(false)
+      SetPasswordMaxError(false)
+    }
+  }, [demo1.password])
 
   const passwordChange = (e) => {
     e.preventDefault()
@@ -55,6 +76,14 @@ export default function Input(demo1) {
             }}
           />
         </Row>
+        {passwordMinError && (
+          <Warning {...password.warning}>
+            Minimum Password Length: <br /> {passwordUpperBound} Characters
+          </Warning>
+        )}
+        {passwordMaxError && (
+          <Warning {...password.warning}> Maximum Password Reached </Warning>
+        )}
       </form>
     </Container>
   )

--- a/src/fixtures/themes.js
+++ b/src/fixtures/themes.js
@@ -81,6 +81,14 @@ export const Themes = (arch) => {
         htmlFor: 'Password',
         color: isCheri ? '#000' : '#fff',
       },
+      warning: {
+        fontFamily: isCheri ? '000' : 'Monaco',
+        fontStyle: 'normal',
+        fontWeight: '400',
+        fontSize: isCheri ? '16px' : '20px',
+        lineHeight: '32px',
+        color: '#f00',
+      },
       button: {
         width: '70px',
         background: `url(${lockIcon})`,


### PR DESCRIPTION
If the the secret is below 4 characters a warning is displayed below. There are also checks to stop empty or small passwords (4 characters) being submitted. A warning is also given for max length (though they are stopped anyway)

<img width="1139" alt="Screenshot 2022-09-01 at 11 37 05" src="https://user-images.githubusercontent.com/35331926/187894973-00a2563d-4dde-4aa4-b5ac-87f1ed2a4a29.png">

<img width="1139" alt="Screenshot 2022-09-01 at 11 37 23" src="https://user-images.githubusercontent.com/35331926/187894984-2eec57fb-c250-463b-9eac-95711eaefa5b.png">

<img width="1139" alt="Screenshot 2022-09-01 at 11 37 29" src="https://user-images.githubusercontent.com/35331926/187895000-42214a5d-8f05-4a27-aa98-5cc0639d6be9.png">

<img width="1139" alt="Screenshot 2022-09-01 at 11 37 33" src="https://user-images.githubusercontent.com/35331926/187895013-1f0444c1-9840-416e-b489-7360d407537d.png">

<img width="1139" alt="Screenshot 2022-09-01 at 11 37 41" src="https://user-images.githubusercontent.com/35331926/187895033-b964ce5e-4179-4ceb-80a9-16338fe182b8.png">

<img width="1139" alt="Screenshot 2022-09-01 at 11 38 03" src="https://user-images.githubusercontent.com/35331926/187895050-396a37a9-0018-4243-af4c-43c6c5533b33.png">

<img width="1139" alt="Screenshot 2022-09-01 at 11 38 11" src="https://user-images.githubusercontent.com/35331926/187895069-13602e25-ae14-4334-b1e0-2c7884e23bbd.png">
