### PR TITLE
Chore/styling improvements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/morello-ui",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/morello-ui",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "license": "Apache-2.0",
       "dependencies": {
         "qs": "^6.11.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/morello-ui",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "User interface for interacting with morello-api",
   "main": "src/index.js",
   "scripts": {

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -1,22 +1,21 @@
 import React from 'react'
-
-import { Root, Container } from './shared/Common'
+import styled from 'styled-components'
 import Router from '../utils/Router'
+
+const Root = styled.div`
+  display: grid;
+  grid-template-areas:
+    'header'
+    'body';
+  grid-template-rows: 164px 1fr;
+  width: 100vw;
+  height: 100vh;
+`
 
 export default function App() {
   return (
-    <Root display={'flex'} justifyContent={'center'} flexDirection={'row'}>
-      <Container
-        size={10}
-        styles={{
-          flexDirection: 'column',
-          overflow: 'hidden',
-          maxHeight: '1024px',
-          maxWidth: '1366px',
-        }}
-      >
-        <Router />
-      </Container>
+    <Root>
+      <Router />
     </Root>
   )
 }

--- a/src/components/Box.js
+++ b/src/components/Box.js
@@ -2,7 +2,7 @@ import React from 'react'
 import styled from 'styled-components'
 
 import Input from './shared/Input'
-import { Col, Row, Txt_Demo1A, renderTitle, Spacer } from './shared/Common'
+import { Col, Row, Txt_Demo1A, renderTitle } from './shared/Common'
 import { Context } from '../utils/context'
 import Modal from './shared/Modal'
 import KeychainIcon from '../assets/images/keychain-strip.png'
@@ -69,7 +69,6 @@ export default function Box(demo1) {
                   Please input a keyword of choice.
                 </Txt_Demo1A>
               </Row>
-              <Spacer size={120} />
               <Row justifyContent={'center'}>
                 <Txt_Demo1A {...font}>
                   Password has been submitted. Now you can attempt to hack

--- a/src/components/Demos/Demo1.js
+++ b/src/components/Demos/Demo1.js
@@ -3,18 +3,24 @@ import styled from 'styled-components'
 
 import Header from '../Header'
 import HackerApp from '../HackerApp'
-import { Context } from '../../utils/context'
+import { Context, initState } from '../../utils/context'
 import Box from '../Box'
 import { ButtonSide } from '../shared/Buttons'
 
-const Wrapper = styled.div((props) => props)
+const Wrapper = styled.div`
+  grid-area: body;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  ${(props) => props}
+`
 
 export default function Demo1(props) {
   const state = React.useContext(Context)
   const demo1 = { ...state.demo1, ...props }
   const { update, Themes } = state
   const { theme } = demo1
-  const { Background } = theme
 
   const switchToMorello = (e) => {
     e.preventDefault()
@@ -38,13 +44,17 @@ export default function Demo1(props) {
     })
   }
 
+  React.useEffect(() => {
+    update(initState)
+  }, [update])
+
   return (
-    <Background>
-      {demo1.showHackPopup && (
-        <ButtonSide {...demo1} action={switchToMorello} />
-      )}
+    <>
       <Header {...demo1} />
       <Wrapper {...theme.wrapper}>
+        {demo1.showHackPopup && (
+          <ButtonSide {...demo1} action={switchToMorello} />
+        )}
         {demo1.isPasswordSet && (
           <HackerApp
             imageSrc={theme.icons.icon}
@@ -54,6 +64,6 @@ export default function Demo1(props) {
         )}
         <Box {...demo1} />
       </Wrapper>
-    </Background>
+    </>
   )
 }

--- a/src/components/HackerApp.js
+++ b/src/components/HackerApp.js
@@ -1,7 +1,12 @@
 import React from 'react'
+import styled from 'styled-components'
 
-import { Col, H2 } from './shared/Common'
+import { H2 } from './shared/Common'
 import { Context } from '../utils/context'
+
+const IconWrapper = styled.div`
+  ${(props) => props.styles}
+`
 
 // usage <Icon imageSrc={cardArrow} text={'txt'} styles={{ width: '100px', textAlign: 'center'}}/>
 export default function Hacker(props) {
@@ -19,21 +24,15 @@ export default function Hacker(props) {
   }
 
   return (
-    <Col
-      id={'hacker-app'}
-      styles={{
-        ...styles,
-        cursor: 'pointer',
-      }}
-      onClick={(e) => renderModal(e, { demo1, update })}
-    >
+    <IconWrapper id={'hacker-app'} styles={styles}>
       <img
-        style={{ padding: '0px 10px' }}
+        style={{ cursor: 'pointer' }}
         src={imageSrc}
         width={'60px'}
         height={'60px'}
+        onClick={(e) => renderModal(e, { demo1, update })}
       />
       <H2>{text}</H2>
-    </Col>
+    </IconWrapper>
   )
 }

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -2,13 +2,16 @@ import React from 'react'
 import styled from 'styled-components'
 import { useNavigate } from 'react-router-dom'
 
-import { H1, Row, Col, RowSpacer } from './shared/Common'
+import { H1 } from './shared/Common'
 import closeIcon from '../assets/images/close-icon.png'
-import { Context, initState } from '../utils/context'
+import { Context } from '../utils/context'
 
-const HeaderStyle = styled.div((props) => props)
+const HeaderStyle = styled.div`
+  ${(props) => props}
+`
 const CloseElement = styled.span({
   display: 'flex',
+  height: '100%',
   alignItems: 'center',
   cursor: 'pointer',
 })
@@ -16,7 +19,6 @@ const CloseElement = styled.span({
 export default function Header(props) {
   const {
     demo1: { theme },
-    update,
   } = React.useContext(Context)
   const nav = useNavigate()
 
@@ -26,39 +28,32 @@ export default function Header(props) {
       {...theme.header}
       backgroundColor={props.color || 'none'}
     >
-      <Row height={'100%'}>
-        <Col size={3} styles={{ paddingLeft: '50px', alignItems: 'start' }}>
-          {props.title ? (
-            <H1
-              lineHeight={'58px'}
-              letterSpacing={'-0.06em'}
-              fontStyle={'normal'}
-              fontWeight={'300'}
-              fontSize={'45px'}
-            >
-              {props.title}
-            </H1>
-          ) : (
-            <img src={props.logo} width={'140px'} height={'38px'} />
-          )}
-        </Col>
-        <RowSpacer size={5} />
-        <Col size={3} styles={{ paddingRight: '50px', alignItems: 'end' }}>
-          {props.showClose && (
-            <CloseElement
-              data-cy={'header-close-btn'}
-              onClick={(e) => {
-                e.preventDefault()
-                update(initState)
-                nav('/', { replace: true })
-              }}
-            >
-              <H1>Close</H1>
-              <img src={closeIcon} />
-            </CloseElement>
-          )}
-        </Col>
-      </Row>
+      {props.title ? (
+        <H1
+          lineHeight={'58px'}
+          letterSpacing={'-0.06em'}
+          fontStyle={'normal'}
+          fontWeight={'300'}
+          fontSize={'45px'}
+        >
+          {props.title}
+        </H1>
+      ) : (
+        <img src={props.logo} width={'140px'} height={'38px'} />
+      )}
+
+      {props.showClose && (
+        <CloseElement
+          data-cy={'header-close-btn'}
+          onClick={(e) => {
+            e.preventDefault()
+            nav('/', { replace: false })
+          }}
+        >
+          <H1>Close</H1>
+          <img src={closeIcon} />
+        </CloseElement>
+      )}
     </HeaderStyle>
   )
 }

--- a/src/components/Info.js
+++ b/src/components/Info.js
@@ -3,24 +3,17 @@ import styled from 'styled-components'
 
 import Header from './Header'
 
-const Wrapper = styled.div`
-  display: flex;
-  flex-direction: column;
-  height: 100vh;
-`
-
 const Content = styled.div`
-  display: flex;
-  background: #F0F0F0;
+  display: grid;
+  grid-area: body;
+  grid-template-columns: minmax(auto, 60vw) minmax(auto, 20vw);
   justify-content: center;
-  height 100%;
-  padding-top: 32px;
-  padding-left: 16px;
-  padding-right: 16px;
+  background: #f0f0f0;
+  padding: 50px 0;
 `
 
 const ScreenshotPicture = styled.picture`
-  align-self: start;
+  margin-right: -100px;
 `
 
 const Screenshot = styled.img`
@@ -28,17 +21,17 @@ const Screenshot = styled.img`
 `
 
 const QrCodeWrap = styled.a`
-  margin-left: -100px;
   align-self: end;
 `
 
 const QrCode = styled.img`
-  max-width: 400px;
+  min-width: 200px;
+  max-width: 25vw;
 `
 
 export default function Demo1(props) {
   return (
-    <Wrapper>
+    <>
       <Header {...props} showClose={true} />
       <Content>
         <ScreenshotPicture>
@@ -56,6 +49,6 @@ export default function Demo1(props) {
           />
         </QrCodeWrap>
       </Content>
-    </Wrapper>
+    </>
   )
 }

--- a/src/components/MainMenu.js
+++ b/src/components/MainMenu.js
@@ -17,8 +17,8 @@ const ItemWrap = styled.div`
 
 const CardLayout = styled(Container)`
   flex-flow: row wrap;
-  gap: 20px;
-  padding: 20px;
+  gap: 10px;
+  padding: 0px 50px 50px 50px;
 `
 
 export default function MainMenu(props) {

--- a/src/components/MainMenu.js
+++ b/src/components/MainMenu.js
@@ -8,7 +8,18 @@ import { Container } from './shared/Common'
 import Header from './Header'
 import dsbdLogo from '../assets/images/logo.png'
 
-const ItemWrap = styled.div(({ styles }) => styles)
+const ItemWrap = styled.div`
+  display: flex;
+  flex-basis: 20vw;
+  min-width: 10rem;
+  background-color: ${(props) => props.color};
+`
+
+const CardLayout = styled(Container)`
+  flex-flow: row wrap;
+  gap: 20px;
+  padding: 20px;
+`
 
 export default function MainMenu(props) {
   const nav = useNavigate()
@@ -16,32 +27,20 @@ export default function MainMenu(props) {
   return (
     <>
       <Header logo={dsbdLogo} {...props} showClose={false} />
-      <Container
-        data-cy={'main-menu-container'}
-        size={10}
-        style={{
-          justifyContent: 'center',
-          flexFlow: 'row wrap',
-        }}
-      >
+      <CardLayout data-cy={'main-menu-container'} size={10}>
         {demos.map((details) => (
           <ItemWrap
-            styles={{
-              display: 'flex',
-              width: '300px',
-              padding: 2,
-              backgroundColor: props.color,
-            }}
+            styles={{}}
             key={details.color}
             onClick={(e) => {
               e.preventDefault()
-              nav(details.path, { replace: true })
+              nav(details.path, { replace: false })
             }}
           >
             <Card {...details} />
           </ItemWrap>
         ))}
-      </Container>
+      </CardLayout>
     </>
   )
 }

--- a/src/components/ProgressBar.js
+++ b/src/components/ProgressBar.js
@@ -32,11 +32,10 @@ export default function ProgressBar({ update, demo1 }) {
 
   React.useEffect(() => {
     async function load() {
-      await fill()
-      const output = await demo1.execute(
-        `${demo1.binaryName}-${theme.arch}`,
-        demo1.password
-      )
+      const [, output] = await Promise.all([
+        fill(),
+        demo1.execute(`${demo1.binaryName}-${theme.arch}`, demo1.password),
+      ])
       update({
         demo1: {
           ...demo1,

--- a/src/components/shared/Buttons.js
+++ b/src/components/shared/Buttons.js
@@ -8,6 +8,7 @@ export const ButtonBasic = styled.button`
   width: 20%;
   height: 50px;
   margin-left: 5px;
+  border: 0;
 `
 
 export function ButtonSide({ action, ...demo1 }) {
@@ -19,16 +20,17 @@ export function ButtonSide({ action, ...demo1 }) {
     width: 55px;
     animation: stepIn 1.3s;
     animation-iteration-count: infinite;
+    margin-right: 2vw;
 
     @keyframes stepIn {
       0% {
-        margin-left: 10px;
+        margin-left: 1vw;
       }
       30% {
-        margin-left: 39px;
+        margin-left: 4vw;
       }
       100% {
-        margin-left: 10px;
+        margin-left: 1vw;
       }
     }
   `

--- a/src/components/shared/Buttons.js
+++ b/src/components/shared/Buttons.js
@@ -40,9 +40,10 @@ export function ButtonSide({ action, ...demo1 }) {
     cursor: pointer;
     padding: 0px 20px;
     align-items: center;
-    height: 696px;
+    height: calc(100vh - 164px);
     opacity: 0.6;
     top: 164px;
+    right: 0px;
     width: auto;
     transition: all 0.6s;
     background-image: url(${backgroundImg});

--- a/src/components/shared/Card.js
+++ b/src/components/shared/Card.js
@@ -15,16 +15,13 @@ const Indicator = styled.div`
 `
 
 const Paper = styled.div`
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  text-align: left;
+  display: grid;
+  grid-template-rows: 1fr auto auto;
   opacity: 1;
-  flex-basis: 20vw;
   cursor: pointer;
   padding: 10px 20px;
   background: ${(props) => props.color};
-  transition: all 0.1s;
+  transition: opacity 0.1s;
   box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.05), 0 1px 3px 0 rgba(0, 0, 0, 0.09);
 
   -webkit-tap-highlight-color: transparent; /* remove tap highlight */
@@ -51,7 +48,6 @@ export default function Card(props) {
       <Indicator>
         <img width={'21px'} height={'21px'} src={cardArrow} />
       </Indicator>
-      <Spacer size={182} />
       <H1>{title}</H1>
       <P1>
         {isDemo ? <b>Bug type: </b> : null}

--- a/src/components/shared/Card.js
+++ b/src/components/shared/Card.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import styled from 'styled-components'
 
-import { H1, P1, Spacer } from './Common'
+import { H1, P1 } from './Common'
 import cardArrow from '../../assets/images/card-arrow.png'
 
 const Indicator = styled.div`

--- a/src/components/shared/Card.js
+++ b/src/components/shared/Card.js
@@ -20,8 +20,7 @@ const Paper = styled.div`
   align-items: flex-start;
   text-align: left;
   opacity: 1;
-  width: 317px;
-  height: 355px;
+  flex-basis: 20vw;
   cursor: pointer;
   padding: 10px 20px;
   background: ${(props) => props.color};

--- a/src/components/shared/Common.js
+++ b/src/components/shared/Common.js
@@ -56,13 +56,6 @@ export const P1 = styled.p((props) => ({
   ...props,
 }))
 
-export const Root = styled.div((props) => ({
-  display: 'block',
-  alignItems: 'center',
-  ...params.screen,
-  ...props,
-}))
-
 // Size gooes from 1 - 10 multiplied by 10
 export const Container = styled.div(({ size = 1, styles = {} }) => ({
   ...params.flex,
@@ -110,14 +103,14 @@ const Title = styled.p((props) => ({
   ...props,
 }))
 
-const Circle = styled.div(({ size = 1, color }) => ({
-  display: 'block',
-  width: `${size * 15}px`,
-  height: `${size * 15}px`,
-  marginLeft: '5px',
-  borderRadius: '50px',
-  backgroundColor: color,
-}))
+const Circle = styled.div`
+  display: block;
+  width: 12px;
+  height: 12px;
+  margin-left: 5px;
+  border-radius: 50%;
+  background-color: ${(props) => props.color};
+`
 
 const aarch64Icons = [crossIcon, icon, minimise]
 const titleProps = {
@@ -135,9 +128,9 @@ const titleProps = {
   },
   Morello: {
     icons: [
-      <Circle key={'osx-title-btn-1'} color='"rgb(255, 59, 48)"' />,
-      <Circle key={'osx-title-btn-2'} color='"rgb(255, 149, 0)"' />,
-      <Circle key={'osx-title-btn-3'} color='"rgb(52, 199, 89)"' />,
+      <Circle key={'osx-title-btn-1'} color={'rgb(255, 59, 48)'} />,
+      <Circle key={'osx-title-btn-2'} color={'rgb(255, 149, 0)'} />,
+      <Circle key={'osx-title-btn-3'} color={'rgb(52, 199, 89)'} />,
     ],
     iconSize: {
       width: '16px',
@@ -153,6 +146,7 @@ const titleProps = {
       background: '-webkit-linear-gradient(top, #40303f, #212124)',
       color: '#4d494d',
       height: '30px',
+      paddingLeft: '5px',
       borderTop: '1px solid #001',
       borderBottom: '1px solid #000',
       borderTopLeftRadius: '6px',

--- a/src/components/shared/Common.js
+++ b/src/components/shared/Common.js
@@ -63,11 +63,6 @@ export const Container = styled.div(({ size = 1, styles = {} }) => ({
   ...styles,
 }))
 
-export const Spacer = styled.div(({ size = 1 }) => ({
-  width: '100%',
-  height: `${size}px`,
-}))
-
 export const Row = styled.div((props) => ({
   display: 'flex',
   width: '100%',

--- a/src/components/shared/Modal.js
+++ b/src/components/shared/Modal.js
@@ -2,7 +2,7 @@ import React from 'react'
 import styled from 'styled-components'
 
 import { Button, ButtonBasic } from './Buttons'
-import { Txt_Demo1A, Col, Row, renderTitle, Spacer } from './Common'
+import { Txt_Demo1A, Col, Row, renderTitle } from './Common'
 
 const Window = styled.div(({ styles }) => styles)
 const Page = styled(Col)((props) => props)
@@ -82,7 +82,6 @@ export default function Modal({ update, demo1, ProgressBar }) {
       <Row flex={'auto'}>
         <Page {...theme.modal.page}>
           <Txt_Demo1A {...demo1.txt_col}>{demo1.modalText}</Txt_Demo1A>
-          <Spacer size={10} />
 
           {renderModalActions && renderActions({ demo1, update })}
           {showHackingProgress && (

--- a/src/fixtures/themes.js
+++ b/src/fixtures/themes.js
@@ -1,5 +1,3 @@
-import styled from 'styled-components'
-
 import backgroundImgOsx from '../assets/images/osx-background.png'
 import iconOsx from '../assets/images/hacker-app-icon-morello.png'
 import lockIconOsx from '../assets/images/lock.png'
@@ -21,8 +19,11 @@ export const Themes = (arch) => {
     header: {
       backgroundColor: '#384D6C',
       width: '100%',
-      zIndex: 999,
-      height: '164px',
+      gridArea: 'header',
+      display: 'flex',
+      justifyContent: 'space-between',
+      alignItems: 'center',
+      padding: '0px 50px',
     },
     progressBar: {
       wrapper: {
@@ -93,12 +94,8 @@ export const Themes = (arch) => {
       },
     },
     wrapper: {
-      display: 'flex',
-      position: 'relative',
-      alignItems: 'center',
-      justifyContent: 'center',
-      width: '100%',
-      height: '100%',
+      backgroundImage: `url(${backgroundImage})`,
+      backgroundSize: 'cover',
     },
     menuItemWrap: {
       display: 'flex',
@@ -110,7 +107,7 @@ export const Themes = (arch) => {
       style: {
         position: 'absolute',
         left: '20px',
-        top: '200px',
+        bottom: '100px',
         width: '60px',
         textAlign: 'center',
       },
@@ -172,14 +169,6 @@ export const Themes = (arch) => {
             boxShadow: '24px 24px 1px rgba(0, 0, 0, 0.8)',
           },
     },
-    Background: styled.div({
-      display: 'flex',
-      flexDirection: 'column',
-      backgroundImage: `url(${backgroundImage})`,
-      width: '100%',
-      height: '860px',
-      overflow: 'hidden',
-    }),
     primary: {
       windowCont: isCheri
         ? {

--- a/src/index.html
+++ b/src/index.html
@@ -9,6 +9,9 @@
         background-color: '#F5F5F5';
         margin: 0px;
       }
+      * {
+        box-sizing: border-box;
+      }
     </style>
     <title>Morello UI</title>
     <meta charset='UTF-8'>


### PR DESCRIPTION
Styling improvements across the board to make the whole design more responsive and simplify the DOM where possible. There's more to do especially within the example at smaller screen sizes but I had to stop somewhere 

![Screen Shot 2022-09-02 at 09 27 53](https://user-images.githubusercontent.com/29942957/188098063-a5c6219b-eaaa-43f9-b02a-42e87d827d34.png)

![Screen Shot 2022-09-02 at 09 28 19](https://user-images.githubusercontent.com/29942957/188098148-44f449e5-36ec-4ab0-8422-27879f88678d.png)

![Screen Shot 2022-09-02 at 09 28 49](https://user-images.githubusercontent.com/29942957/188098235-494edec9-17a1-42e1-89d3-0dc11a22c8dd.png)

![Screen Shot 2022-09-02 at 09 29 21](https://user-images.githubusercontent.com/29942957/188098330-62cba1b6-4b15-4a7b-b7b1-7411ff5c1e7b.png)

![Screen Shot 2022-09-02 at 09 29 54](https://user-images.githubusercontent.com/29942957/188098464-3bbea81b-877a-4482-9054-86a419159a2a.png)
