### PR TITLE
DSBD-34: read demo cypress e2e test scenarios with a few minor changes.

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -48,7 +48,6 @@
         "prettier/prettier": "warn",
         "no-unused-vars": ["error", { "ignoreRestSiblings": true }],
         "cypress/no-assigning-return-values": "error",
-        "cypress/no-unnecessary-waiting": "error",
         "cypress/assertion-before-screenshot": "warn",
         "cypress/no-force": "warn",
         "cypress/no-async-tests": "error",

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -75,6 +75,12 @@ jobs:
           node-version: 16.x
       - name: Install dependencies
         run: npm ci
+      - name: Setup dependencies
+        run: docker-compose up -d
+      - name: Sleep
+        uses: kibertoad/wait-action@1.0.1
+        with:
+          time: '60s'
       - name: Run cypress integration tests
         uses: cypress-io/github-action@v4
         with:

--- a/cypress/integration/read-demo.spec.js
+++ b/cypress/integration/read-demo.spec.js
@@ -245,12 +245,12 @@ describe('Read Demo', () => {
             .and('include.text', 'hacking in progress 98%')
         })
 
-        it('renders FAILURE message with details button', () => {
+        it('renders HACK FAILED message with details button', () => {
           cy.wait(30000)
           cy.get('[data-cy=progress-bar-text]')
             .should(
               'include.text',
-              'FAILURE. The password could not be revealed. - Display output?'
+              'HACK FAILED. The password could not be revealed!?'
             )
             .and('not.include.text', secret)
         })

--- a/cypress/integration/read-demo.spec.js
+++ b/cypress/integration/read-demo.spec.js
@@ -132,7 +132,7 @@ describe('Read Demo', () => {
       })
 
       it('displays user`s password', { defaultCommandTimeout: 60000 }, () => {
-        cy.wait(delay)
+        cy.wait(30000)
         cy.get('[data-cy=progress-bar-text]').should('include.text', secret)
       })
 
@@ -246,7 +246,7 @@ describe('Read Demo', () => {
         })
 
         it('renders FAILURE message with details button', () => {
-          cy.wait(delay)
+          cy.wait(30000)
           cy.get('[data-cy=progress-bar-text]')
             .should(
               'include.text',

--- a/cypress/integration/read-demo.spec.js
+++ b/cypress/integration/read-demo.spec.js
@@ -39,7 +39,7 @@ describe('Read Demo', () => {
         .and('contain', 'rgba(0, 0, 0, 0)')
     })
 
-    describe('Enters to long password', () => {
+    describe('Enters too long password', () => {
       it('cuts off long passwords', () => {
         // eslint-disable-next-line cypress/no-force
         cy.get('[data-cy=password-input-box]', {

--- a/cypress/integration/read-demo.spec.js
+++ b/cypress/integration/read-demo.spec.js
@@ -1,6 +1,5 @@
-describe('Read Demo', () => {
+describe('Read Demo', { defaultCommandTimeout: 60000 }, () => {
   const secret = 'shhh-secret'
-  const delay = 10000
 
   beforeEach(() => {
     cy.visit('/read-demo')
@@ -131,13 +130,11 @@ describe('Read Demo', () => {
           .and('include.text', 'hacking in progress 98%')
       })
 
-      it('displays user`s password', { defaultCommandTimeout: 60000 }, () => {
-        cy.wait(30000)
+      it('displays user`s password', () => {
         cy.get('[data-cy=progress-bar-text]').should('include.text', secret)
       })
 
       it('renders a side button for demo 1b', () => {
-        cy.wait(delay)
         cy.get('[data-cy=button-side]').should('exist').and('include.text', '')
       })
     })
@@ -148,8 +145,6 @@ describe('Read Demo', () => {
         cy.get('[data-cy=submit-password-btn]').click()
         cy.get('[data-cy=hacker-app]').click()
         cy.get('[data-cy=modal-btn-yes-aarch64]').click()
-        // TODO figure out a better way (quicker either to wrap in describe blocks or...)
-        cy.wait(delay)
         cy.get('[data-cy=button-side]').click()
       })
 
@@ -245,8 +240,7 @@ describe('Read Demo', () => {
             .and('include.text', 'hacking in progress 98%')
         })
 
-        it('renders HACK FAILED message with details button', () => {
-          cy.wait(30000)
+        it('renders HACK FAILED', () => {
           cy.get('[data-cy=progress-bar-text]')
             .should(
               'include.text',
@@ -260,7 +254,6 @@ describe('Read Demo', () => {
         })
 
         it('renders Learn More side button', () => {
-          cy.wait(delay)
           cy.get('[data-cy=button-side]')
             .should('exist')
             .and('include.text', 'Learn More')

--- a/cypress/integration/read-demo.spec.js
+++ b/cypress/integration/read-demo.spec.js
@@ -1,51 +1,275 @@
 describe('Read Demo', () => {
+  const secret = 'shhh-secret'
+  const delay = 10000
+
   beforeEach(() => {
     cy.visit('/read-demo')
   })
 
-  // TODO use data= property for getting DOM elements
-  it('Renders login box', () => {
-    cy.get('[data-cy=password]').should('exist')
-  })
+  describe('Header', () => {
+    it('renders read demo header', () => {
+      cy.get('[data-cy=header]')
+        .should('include.text', 'Are your secrets really safe?')
+        .should('have.css', 'background-color')
+        .and('contain', 'rgb(56, 77, 108)')
 
-  it('Returns to main menu and confirm that menu container has been rendered', () => {
-    cy.get('[data-cy=header-close-btn]').click()
-    cy.get('[data-cy=main-menu-container]').should('exist')
-  })
+      cy.get('[data-cy=header-close-btn]')
+        .should('exist')
+        .and('include.text', 'Close')
+    })
 
-  describe('If password entered is more than 16 chars', () => {
-    it('Max length cuts off long passwords', () => {
-      // eslint-disable-next-line cypress/no-force
-      cy.get('[data-cy=password]', { maxlength: 16, force: true }).type(
-        '12345678910111213141516',
-        { force: true }
-      )
-      cy.get('[data-cy=password]').should('have.value', '1234567891011121')
+    it('clicking on close button takes to the main menu', () => {
+      cy.get('[data-cy=header-close-btn]').click()
+      cy.get('[data-cy=main-menu-container]').should('exist')
     })
   })
 
   describe('Happy path', () => {
-    beforeEach(() => {
-      cy.get('[data-cy=password]').type('password')
-      cy.get('[data-cy=submit-password]').click()
-      cy.get('[data-cy=hacker-app]').click()
-      cy.get('[data-cy=read-demo-modal-btn-yes-2]').click()
+    it('confirms styling and DOM elements Demo 1A', () => {
+      // TODO expand by creating an object of props from (theme.js)
+      // and asserting each of mmain components
+      cy.get('[data-cy=content-container]')
+        .should('have.css', 'background-color')
+        .and('contain', 'rgb(52, 53, 86)')
+      cy.get('[data-cy=password-input-box]')
+        .should('have.css', 'background-color')
+        .and('contain', 'rgb(52, 53, 86)')
+      cy.get('[data-cy=submit-password-btn]')
+        .should('have.css', 'background-color')
+        .and('contain', 'rgba(0, 0, 0, 0)')
     })
 
-    it('Renders Hacker App after submitting a password', () => {
-      cy.get('[data-cy=hacker-app]').should('exist')
+    describe('Enters to long password', () => {
+      it('cuts off long passwords', () => {
+        // eslint-disable-next-line cypress/no-force
+        cy.get('[data-cy=password-input-box]', {
+          maxlength: 16,
+          force: true,
+        }).type('12345678910111213141516', { force: true })
+        cy.get('[data-cy=password-input-box]').should(
+          'have.value',
+          '1234567891011121'
+        )
+      })
+      // TODO assert for error text
     })
 
-    it('Renders modal after clicking on Hacker App', () => {
-      cy.get('[data-cy=hacker-app-modal]').should('exist')
+    describe('Submits password', () => {
+      beforeEach(() => {
+        cy.get('[data-cy=password-input-box]').type(secret)
+        cy.get('[data-cy=submit-password-btn]').click()
+      })
+
+      it('renders hacker app', () => {
+        cy.get('[data-cy=hacker-app]').should('exist')
+        cy.get('[data-cy=hacker-app-icon]')
+          .should('exist')
+          .and('have.css', 'background-image')
+          .and('to.be.ok')
+        cy.get('[data-cy=hacker-app-icon-text]')
+          .should('have.css', 'font-family')
+          .and('contain', 'AktivGrotesk')
+      })
+
+      it('removes password form', () => {
+        cy.get('[data-cy=password-input-box]').should('not.exist')
+        cy.get('[data-cy=submit-password-btn]').should('not.exist')
+      })
     })
 
-    it('Renders progress bar after clicking <YES>', () => {
-      cy.get('[data-cy=read-demo-progress-bar]').should('exist')
+    describe('Opens hacker app', () => {
+      beforeEach(() => {
+        cy.get('[data-cy=password-input-box]').type(secret)
+        cy.get('[data-cy=submit-password-btn]').click()
+        cy.get('[data-cy=hacker-app]').click()
+      })
+      describe('Selects [no] option', () => {
+        beforeEach(() => {
+          cy.get('[data-cy=modal-btn-no-aarch64]').click()
+        })
+
+        it('updates state so moddal is no longer rendered', () => {
+          cy.get('[data-cy=modal-main]').should('not.exist')
+        })
+      })
+
+      it('renders modal with yes/no option', () => {
+        cy.get('[data-cy=modal-main]').should('exist')
+        cy.get('[data-cy=modal-main-text]')
+          .should('exist')
+          .should(
+            'include.text',
+            'Would you like to break into the system and reveal the password?'
+          )
+        cy.get('[data-cy=modal-btn-yes-aarch64]')
+          .should('exist')
+          .and('include.text', 'YES')
+          .and('have.css', 'font-family')
+          .and('contain', 'Arial')
+        cy.get('[data-cy=modal-btn-no-aarch64]')
+          .should('exist')
+          .and('include.text', 'NO')
+          .and('have.css', 'font-family')
+          .and('contain', 'Arial')
+      })
     })
 
-    it.skip('Executes read demo binaries by calling an api', () => {
-      // TODO
+    describe('Initiates hacking', () => {
+      beforeEach(() => {
+        cy.get('[data-cy=password-input-box]').type(secret)
+        cy.get('[data-cy=submit-password-btn]').click()
+        cy.get('[data-cy=hacker-app]').click()
+        cy.get('[data-cy=modal-btn-yes-aarch64]').click()
+      })
+
+      it('renders progress animation', () => {
+        cy.get('[data-cy=progress-bar]')
+          .should('exist')
+          .and('include.text', 'hacking in progress')
+        cy.get('[data-cy=progress-bar]')
+          .should('exist')
+          .and('include.text', 'hacking in progress 98%')
+      })
+
+      it('displays user`s password', { defaultCommandTimeout: 60000 }, () => {
+        cy.wait(delay)
+        cy.get('[data-cy=progress-bar-text]').should('include.text', secret)
+      })
+
+      it('renders a side button for demo 1b', () => {
+        cy.wait(delay)
+        cy.get('[data-cy=button-side]').should('exist').and('include.text', '')
+      })
+    })
+
+    describe('Demo 1B', () => {
+      beforeEach(() => {
+        cy.get('[data-cy=password-input-box]').type(secret)
+        cy.get('[data-cy=submit-password-btn]').click()
+        cy.get('[data-cy=hacker-app]').click()
+        cy.get('[data-cy=modal-btn-yes-aarch64]').click()
+        // TODO figure out a better way (quicker either to wrap in describe blocks or...)
+        cy.wait(delay)
+        cy.get('[data-cy=button-side]').click()
+      })
+
+      it('confirms styling and DOM elements of Demo 1B', () => {
+        // TODO refer to demo 1a it block
+        cy.get('[data-cy=content-container]')
+          .should('have.css', 'background-color')
+          .and('contain', 'rgb(255, 255, 255)')
+        cy.get('[data-cy=password-input-box]')
+          .should('have.css', 'background-color')
+          .and('contain', 'rgb(255, 255, 255)')
+        cy.get('[data-cy=submit-password-btn]')
+          .should('have.css', 'background-color')
+          .and('contain', 'rgba(0, 0, 0, 0)')
+      })
+
+      describe('Submits password', () => {
+        beforeEach(() => {
+          cy.get('[data-cy=password-input-box]').type(secret)
+          cy.get('[data-cy=submit-password-btn]').click()
+        })
+
+        it('renders morello hacker app', () => {
+          // TODO assert that it's morello icon?
+          cy.get('[data-cy=hacker-app]').should('exist')
+          cy.get('[data-cy=hacker-app-icon]')
+            .should('exist')
+            .and('have.css', 'background-image')
+            .and('to.be.ok')
+          cy.get('[data-cy=hacker-app-icon-text]')
+            .should('have.css', 'font-family')
+            .and('contain', 'AktivGrotesk')
+        })
+
+        it('removes password input', () => {
+          cy.get('[data-cy=password-input-box]').should('not.exist')
+          cy.get('[data-cy=submit-password-btn]').should('not.exist')
+        })
+      })
+
+      describe('Opens hacker app', () => {
+        beforeEach(() => {
+          cy.get('[data-cy=password-input-box]').type(secret)
+          cy.get('[data-cy=submit-password-btn]').click()
+          cy.get('[data-cy=hacker-app]').click()
+        })
+
+        describe('Selects [no] option', () => {
+          beforeEach(() => {
+            cy.get('[data-cy=modal-btn-no-cheri]').click()
+          })
+
+          it('updates state so moddal is no longer rendered', () => {
+            cy.get('[data-cy=modal-main]').should('not.exist')
+          })
+        })
+
+        it('renders modal with yes/no option', () => {
+          cy.get('[data-cy=modal-main]').should('exist')
+          cy.get('[data-cy=modal-main-text]')
+            .should('exist')
+            .should(
+              'include.text',
+              'Would you like to break into the system and reveal the password?'
+            )
+          cy.get('[data-cy=modal-btn-yes-cheri]')
+            .should('exist')
+            .and('include.text', 'YES')
+            .and('have.css', 'font-family')
+            .and('contain', 'Arial')
+          cy.get('[data-cy=modal-btn-no-cheri]')
+            .should('exist')
+            .and('include.text', 'NO')
+            .and('have.css', 'font-family')
+            .and('contain', 'Arial')
+        })
+      })
+
+      describe('Initiates hacking', () => {
+        beforeEach(() => {
+          cy.get('[data-cy=password-input-box]').type(secret)
+          cy.get('[data-cy=submit-password-btn]').click()
+          cy.get('[data-cy=hacker-app]').click()
+          cy.get('[data-cy=modal-btn-yes-cheri]').click()
+        })
+
+        it('renders progress animation', () => {
+          cy.get('[data-cy=progress-bar]')
+            .should('exist')
+            .and('include.text', 'hacking in progress')
+          cy.get('[data-cy=progress-bar]')
+            .should('exist')
+            .and('include.text', 'hacking in progress 98%')
+        })
+
+        it('renders FAILURE message with details button', () => {
+          cy.wait(delay)
+          cy.get('[data-cy=progress-bar-text]')
+            .should(
+              'include.text',
+              'FAILURE. The password could not be revealed. - Display output?'
+            )
+            .and('not.include.text', secret)
+        })
+
+        it.skip('details button renders a concole with all output', () => {
+          // TOOD implement once merged
+        })
+
+        it('renders Learn More side button', () => {
+          cy.wait(delay)
+          cy.get('[data-cy=button-side]')
+            .should('exist')
+            .and('include.text', 'Learn More')
+          cy.get('[data-cy=button-side]').click()
+          cy.get('[data-cy=content-container]').should('not.exist')
+          cy.get('[data-cy=password-input-box]').should('not.exist')
+          cy.get('[data-cy=submit-password-btn]').should('not.exist')
+        })
+      })
     })
   })
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/morello-ui",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/morello-ui",
-      "version": "0.6.1",
+      "version": "0.7.0",
       "license": "Apache-2.0",
       "dependencies": {
         "qs": "^6.11.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/morello-ui",
-  "version": "0.5.2",
+  "version": "0.6.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/morello-ui",
-      "version": "0.5.2",
+      "version": "0.6.0",
       "license": "Apache-2.0",
       "dependencies": {
         "qs": "^6.11.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/morello-ui",
-  "version": "0.5.2",
+  "version": "0.6.0",
   "description": "User interface for interacting with morello-api",
   "main": "src/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/morello-ui",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "description": "User interface for interacting with morello-api",
   "main": "src/index.js",
   "scripts": {

--- a/src/components/demos/read/Demo.js
+++ b/src/components/demos/read/Demo.js
@@ -141,14 +141,14 @@ export default function ReadDemo(props) {
                       setInputState={setPasswordInput}
                       inputType={'password'}
                       upperBound={passwordUpperBound}
-                      cySelector={'password'}
+                      cySelector={'password-input-box'}
                       showInputError={passwordAtMaxLength || noPasswordEntered}
                       InputErrorWarning={InputErrorWarning}
                     />
                     <Button
                       {...readDemo.theme.form.savePasswordButton}
                       type={'submit'}
-                      data-cy={'submit-password'}
+                      data-cy={'submit-password-btn'}
                     />
                   </Container>
                 </form>

--- a/src/components/demos/read/HackerApp.js
+++ b/src/components/demos/read/HackerApp.js
@@ -28,13 +28,14 @@ export default function Hacker(props) {
   return (
     <IconWrapper data-cy={'hacker-app'}>
       <img
+        data-cy={'hacker-app-icon'}
         style={{ cursor: 'pointer' }}
         src={imageSrc}
         width={'60px'}
         height={'60px'}
         onClick={(e) => renderModal(e, { readDemo, update })}
       />
-      <H2>{text}</H2>
+      <H2 data-cy={'hacker-app-icon-text'}>{text}</H2>
     </IconWrapper>
   )
 }

--- a/src/components/demos/read/Modal.js
+++ b/src/components/demos/read/Modal.js
@@ -31,12 +31,12 @@ const renderActions = ({ update, readDemo }) => {
     })
   }
 
-  const btn = () =>
+  const btn = ({ cyPrefix = '' }) =>
     readDemo.theme.name === 'Morello'
       ? [
           <Button
             key={'read-demo-modal-btn-yes-1'}
-            data-cy={'read-demo-modal-btn-yes-1'}
+            data-cy={`${cyPrefix}modal-btn-yes-cheri`}
             onClick={handleYes}
           >
             YES
@@ -44,8 +44,8 @@ const renderActions = ({ update, readDemo }) => {
           <div key={'div-1'} style={{ width: '30px' }} />,
           <Button
             key={'read-demo-modal-btn-no-1'}
-            data-cy={'read-demo-modal-btn-no-1'}
-            OnClick={handleNo}
+            data-cy={`${cyPrefix}modal-btn-no-cheri`}
+            onClick={handleNo}
           >
             NO
           </Button>,
@@ -53,14 +53,14 @@ const renderActions = ({ update, readDemo }) => {
       : [
           <ButtonBasic
             key={'read-demo-modal-btn-yes-2'}
-            data-cy={'read-demo-modal-btn-yes-2'}
+            data-cy={`${cyPrefix}modal-btn-yes-aarch64`}
             onClick={handleYes}
           >
             YES
           </ButtonBasic>,
           <ButtonBasic
             key={'read-demo-modal-btn-no-2'}
-            data-cy={'read-demo-modal-btn-no-2'}
+            data-cy={`${cyPrefix}modal-btn-no-aarch64`}
             onClick={handleNo}
           >
             NO
@@ -69,7 +69,7 @@ const renderActions = ({ update, readDemo }) => {
 
   return (
     <Row justifyContent={'center'} padding={'10px'}>
-      {btn()}
+      {btn({})}
     </Row>
   )
 }
@@ -78,11 +78,13 @@ export default function Modal({ update, readDemo, ProgressBar }) {
   const { theme, showHackingProgress, renderModalActions } = readDemo
 
   return (
-    <Window data-cy={'hacker-app-modal'} styles={theme.modal.window}>
+    <Window data-cy={'modal-main'} styles={theme.modal.window}>
       <Title title={readDemo.modalTitle} arch={theme.name} />
       <Row flex={'auto'}>
         <Page {...theme.modal.page}>
-          <DemoText {...readDemo.txt_col}>{readDemo.modalText}</DemoText>
+          <DemoText data-cy={'modal-main-text'} {...readDemo.txt_col}>
+            {readDemo.modalText}
+          </DemoText>
 
           {renderModalActions && renderActions({ readDemo, update })}
           {showHackingProgress && (

--- a/src/components/demos/read/ProgressBar.js
+++ b/src/components/demos/read/ProgressBar.js
@@ -19,7 +19,7 @@ const extractPassword = ({ output }) =>
     .pop()
     .trim()
 
-export default function ProgressBar({ update, readDemo }) {
+export default function ProgressBar({ update, readDemo, cyPrefix = '' }) {
   const [progress, setProgress] = React.useState(10)
   const { theme } = readDemo
 
@@ -56,14 +56,17 @@ export default function ProgressBar({ update, readDemo }) {
   const showProgress = progress !== 100
 
   return showProgress ? (
-    <Wrapper data-cy={'read-demo-progress-bar'} {...theme.progressBar.wrapper}>
+    <Wrapper data-cy={`${cyPrefix}progress-bar`} {...theme.progressBar.wrapper}>
       <DemoText>{`hacking in progress ${progress}%`}</DemoText>
       <BarBackground {...theme.progressBar.background} />
       <Bar progress={progress} {...theme.progressBar.bar} />
     </Wrapper>
   ) : (
     <Row>
-      <DemoText wordWrap={'break-word'}>
+      <DemoText
+        data-cy={`${cyPrefix}progress-bar-text`}
+        wordWrap={'break-word'}
+      >
         {readDemo.output.status != 'success'
           ? 'FAILURE. The password could not be revealed. - Display output?'
           : `Your password is ${extractPassword(readDemo.output)}!`}

--- a/src/components/demos/read/ProgressBar.js
+++ b/src/components/demos/read/ProgressBar.js
@@ -67,9 +67,13 @@ export default function ProgressBar({ update, readDemo, cyPrefix = '' }) {
         data-cy={`${cyPrefix}progress-bar-text`}
         wordWrap={'break-word'}
       >
-        {readDemo.output.status != 'success'
-          ? 'HACK FAILED. The password could not be revealed!?'
-          : <>Your password is <b>${extractPassword(readDemo.output)}</b>!</>}
+        {readDemo.output.status != 'success' ? (
+          'HACK FAILED. The password could not be revealed!?'
+        ) : (
+          <>
+            Your password is <b>${extractPassword(readDemo.output)}</b>!
+          </>
+        )}
       </DemoText>
     </Row>
   )

--- a/src/components/demos/read/ProgressBar.js
+++ b/src/components/demos/read/ProgressBar.js
@@ -71,7 +71,7 @@ export default function ProgressBar({ update, readDemo, cyPrefix = '' }) {
           'HACK FAILED. The password could not be revealed!?'
         ) : (
           <>
-            Your password is <b>${extractPassword(readDemo.output)}</b>!
+            Your password is <b>{extractPassword(readDemo.output)}</b>!
           </>
         )}
       </DemoText>

--- a/src/components/shared/Box.js
+++ b/src/components/shared/Box.js
@@ -11,7 +11,11 @@ export default function Box(props) {
   const { theme } = props
 
   return (
-    <Window data-cy={'content-container'} {...theme.primary.window} {...theme.primary.demoWindow}>
+    <Window
+      data-cy={'content-container'}
+      {...theme.primary.window}
+      {...theme.primary.demoWindow}
+    >
       <Title title={props.windowTitle} arch={theme.name} />
       <Row flex={'auto'}>
         <Body {...theme.primary.windowBody}>{props.children}</Body>

--- a/src/components/shared/Box.js
+++ b/src/components/shared/Box.js
@@ -14,7 +14,7 @@ export default function Box(props) {
   const { theme } = props
 
   return (
-    <Window {...theme.primary.windowCont}>
+    <Window data-cy={'content-container'} {...theme.primary.windowCont}>
       <Title title={props.windowTitle} arch={theme.name} />
       <Row flex={'auto'}>
         <Body {...theme.primary.windowBody}>{props.children}</Body>

--- a/src/components/shared/Buttons.js
+++ b/src/components/shared/Buttons.js
@@ -54,7 +54,7 @@ const SideButton = styled.div`
     }
   }
 `
-const LearnMessage = styled.p`
+const SideButtonTxt = styled.p`
   color: rgba(255, 255, 255, 1);
   font-size: 25px;
   z-index: 50;
@@ -63,12 +63,16 @@ const LearnMessage = styled.p`
   width: 10vw;
 `
 
-export function ButtonSide({ action, message = '' }) {
+export function ButtonSide({ action, message = '', cyPrefix = '' }) {
   return (
     <>
-      <SideButton onClick={action}>
+      <SideButton data-cy={`${cyPrefix}button-side`} onClick={action}>
         <Arrow />
-        <LearnMessage>{message}</LearnMessage>
+        {message && (
+          <SideButtonTxt data-cy={`${cyPrefix}button-side-text`}>
+            {message}
+          </SideButtonTxt>
+        )}
       </SideButton>
     </>
   )

--- a/src/components/shared/Title.js
+++ b/src/components/shared/Title.js
@@ -82,7 +82,9 @@ export default function Title({ title, arch }) {
   return (
     <Row alignItems={'center'} {...props.bar}>
       {props.icons.map((icon) => icon)}
-      <TitleText {...props.text}>{title}</TitleText>
+      <TitleText data-cy={'title-bar'} {...props.text}>
+        {title}
+      </TitleText>
     </Row>
   )
 }


### PR DESCRIPTION
### What

E2E Integration tests for the **read demo**. This suite covers full user's flow (demo 1a and demo 1b) and responses. It also does minimum check to confirm that right template has been loaded and some errors e.g. password too long.  There are areas to expand on which I left in the comments.

#### Coverage
```
====================================================================================================

  (Run Starting)

  ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
  │ Cypress:        10.4.0                                                                         │
  │ Browser:        Electron 102 (headless)                                                        │
  │ Node Version:   v16.14.2 (/Users/PMichelevicius/.nvm/versions/node/v16.14.2/bin/node)          │
  │                 m                                                                              │
  │ Specs:          1 found (read-demo.spec.js)                                                    │
  │ Searched:       cypress/integration/read-demo.spec.js                                          │
  └────────────────────────────────────────────────────────────────────────────────────────────────┘


────────────────────────────────────────────────────────────────────────────────────────────────────
                                                                                                    
    Running:  read-demo.spec.js                                                               (3 of 5)


  Read Demo
    Header
      ✓ renders read demo header (458ms)
      ✓ clicking on close button takes to the main menu (482ms)
    Happy path
      ✓ confirms styling and DOM elements Demo 1A (231ms)
      Enters too long password
        ✓ cuts off long passwords (731ms)
      Submits password
        ✓ renders hacker app (608ms)
        ✓ removes password form (610ms)
      Opens hacker app
        ✓ renders modal with yes/no option (753ms)
        Selects [no] option
          ✓ updates state so moddal is no longer rendered (809ms)
      Initiates hacking
        ✓ renders progress animation (2235ms)
        ✓ displays user`s password (10406ms)
        ✓ renders a side button for demo 1b (7690ms)
      Demo 1B
        ✓ confirms styling and DOM elements of Demo 1B (8327ms)
        Submits password
          ✓ renders morello hacker app (8575ms)
          ✓ removes password input (9214ms)
        Opens hacker app
          ✓ renders modal with yes/no option (9660ms)
          Selects [no] option
            ✓ updates state so moddal is no longer rendered (8882ms)
        Initiates hacking
          ✓ renders progress animation (10253ms)
          ✓ renders HACK FAILED (23097ms)
          - details button renders a concole with all output
          ✓ renders Learn More side button (15459ms)

```