### PR TITLE
Fix maximum length being shown on empty input

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/morello-ui",
-  "version": "0.6.1",
+  "version": "0.6.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/morello-ui",
-      "version": "0.6.1",
+      "version": "0.6.3",
       "license": "Apache-2.0",
       "dependencies": {
         "qs": "^6.11.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/morello-ui",
-  "version": "0.6.1",
+  "version": "0.6.3",
   "description": "User interface for interacting with morello-api",
   "main": "src/index.js",
   "scripts": {

--- a/src/components/demos/read/Demo.js
+++ b/src/components/demos/read/Demo.js
@@ -51,7 +51,8 @@ export default function ReadDemo(props) {
 
   const switchToMorello = (e) => {
     e.preventDefault()
-
+    setPasswordInput('')
+    setSomeInputTyped(false)
     update({
       readDemo: {
         ...readDemo,


### PR DESCRIPTION
This fixes the issue on 1.b where the `Maximum Length Required` would be shown on an empty input. 

<img width="1341" alt="Screenshot 2022-09-20 at 11 28 49" src="https://user-images.githubusercontent.com/35331926/191236443-d5beeb76-ffd4-469e-a10e-2f6f260cb162.png">

**Before**

<img width="1341" alt="Screenshot 2022-09-20 at 11 34 18" src="https://user-images.githubusercontent.com/35331926/191236575-4d608a3e-654d-4092-bcac-da85e7db1f4c.png">

**After**

<img width="1341" alt="Screenshot 2022-09-20 at 11 29 09" src="https://user-images.githubusercontent.com/35331926/191236635-05f8008f-5729-450d-92dc-389b3f5d5be9.png">

<img width="1341" alt="Screenshot 2022-09-20 at 11 29 18" src="https://user-images.githubusercontent.com/35331926/191236654-d827f86a-d2a9-4107-a240-d5bbc5716257.png">
