### PR TITLE
DSBD-103: fixing release workflow by adding docker-compose.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,6 +84,12 @@ jobs:
           node-version: 16.x
       - name: Install dependencies
         run: npm ci
+      - name: Setup dependencies
+        run: docker-compose up -d
+      - name: Sleep
+        uses: kibertoad/wait-action@1.0.1
+        with:
+          time: '60s'
       - name: Run cypress integration tests
         uses: cypress-io/github-action@v4
         with:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digicatapult/morello-ui",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@digicatapult/morello-ui",
-      "version": "0.7.2",
+      "version": "0.7.3",
       "license": "Apache-2.0",
       "dependencies": {
         "qs": "^6.11.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@digicatapult/morello-ui",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "User interface for interacting with morello-api",
   "main": "src/index.js",
   "scripts": {


### PR DESCRIPTION
### What

Fixing a basic bug. Since we do have an E2E testing we need other spin up other dependant services e.g. qemu, api.
- Adding docker-compose up to the release flow.